### PR TITLE
Improvements on regex and detect more date formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,16 +19,32 @@ function getTooltipCoordinate(selection) {
 }
 
 function canBeDate(text) {
-  const dateFormatRegex = /^[\S]+?[ /.-][\S]+?[ /.,-]\d{2,4}$/;
+  // remove extra spaces at the beginning or end:
+  text = text.trim();
 
-  if (/.{6,20}/.test(text)
-    // regex to check different date format
-    && dateFormatRegex.test(text)
-  ) {
-    return true;
+  if (!/^.{6,30}$/.test(text)) {
+    return false;
   }
 
-  return false;
+  const datePatterns = [
+    // ISO format dates:
+    // "Y-M-D" or "Y/M/D" or "Y.M.D"
+    /^\d{4}[\/\-.]\d{1,2}[\/\-.]\d{1,2}$/,
+
+    // Day or Month at first: 
+    // "D/M/Y" or "D-M-Y" or "D.M.Y" or etc.
+    /^\d{1,2}[\/\-.]\d{1,2}[\/\-.]\d{2,4}$/,
+
+    // Month name (full or short) followed by day and year:
+    // "M D, Y" or "M D Y"
+    /^(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2},?\s+\d{2,4}$/i,
+
+    // Day followed by month name (full or short) and year:
+    // "D M, Y" or "D M Y"
+    /^\d{1,2}\s+(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?),?\s+\d{2,4}$/i,
+  ];
+
+  return datePatterns.some(regex => regex.test(text));
 }
 
 function processSelection(selection) {

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function canBeDate(text) {
     /^\d{4}[\/\-.]\d{1,2}[\/\-.]\d{1,2}$/,
 
     // Day or Month at first: 
-    // "D/M/Y" or "D-M-Y" or "D.M.Y" or etc.
+    // "M/D/Y" or "M-D-Y" or "M.D.Y" or etc.
     /^\d{1,2}[\/\-.]\d{1,2}[\/\-.]\d{2,4}$/,
 
     // Month name (full or short) followed by day and year:

--- a/index.js
+++ b/index.js
@@ -37,18 +37,19 @@ function canBeDate(text) {
 
     // Month name (full or short) followed by day and year:
     // "M D, Y" or "M D Y"
-    /^(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2},?\s+\d{2,4}$/i,
+    /^(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s+\d{1,2}(?:st|nd|rd|th)?,?\s+\d{2,4}$/i,
 
     // Day followed by month name (full or short) and year:
     // "D M, Y" or "D M Y"
-    /^\d{1,2}\s+(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?),?\s+\d{2,4}$/i,
+    /^\d{1,2}(?:st|nd|rd|th)?\s+(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?),?\s+\d{2,4}$/i,
   ];
 
   return datePatterns.some(regex => regex.test(text));
 }
 
 function processSelection(selection) {
-  const selectionContent = selection.toString().trim();
+  // trim, then remove st, nd, rd, th from day numbers if exist:
+  const selectionContent = selection.toString().trim().replace(/\b(\d+)(st|nd|rd|th)\b/gi, '$1');
 
   if (!canBeDate(selectionContent)) return null;
 


### PR DESCRIPTION
I cleaned the regex and added support for more date formats, summary:

- **ISO date formats:** "2025-03-31" or "2025-3-31" or etc. (also `/` and `.` allowed instead of `-`)
- **~Day or~ month at first:** "~31/03/2025~" or "03/31/2025" or etc. (also `/` and `.` allowed instead of `-`)
- **Month name (full or short) followed by day and year:** "Mar 31, 2025" or "March 31, 2025" (comma is optional)
- **Day followed by month name (full or short) and year:** "31 Mar, 2025" or "31 March, 2025" (comma is optional)
- **Days could be ordinal number, too:** like " "3rd Mar, 2025"