### PR TITLE
support only year and year+month date strings

### DIFF
--- a/convert.js
+++ b/convert.js
@@ -13,6 +13,8 @@ function getEstimatedJalaliString(year, month = null) {
         const yearStr1 = onlyYearDateFormatter.format(new Date(year, month, 1));
         const yearStr2 = onlyYearDateFormatter.format(new Date(year, month, 28));
 
+        // check negative years
+        if (yearStr1.includes('−') || yearStr2.includes('−')) return null
 
         // TODO: handle for 31-days months
         let month1 = getJalaliMonthName(year, month, 1)
@@ -37,6 +39,9 @@ function getEstimatedJalaliString(year, month = null) {
     const onlyYearDateFormatter = new Intl.DateTimeFormat("fa-IR", { year: 'numeric' })
     let yearStr1 = onlyYearDateFormatter.format(date1);
     let yearStr2 = onlyYearDateFormatter.format(date2);
+    // check negative years
+    if (yearStr1.includes('−') || yearStr2.includes('−')) return null
+
     if (yearStr1 == yearStr2) {
         return yearStr1;
     }

--- a/convert.js
+++ b/convert.js
@@ -19,14 +19,14 @@ function getEstimatedJalaliString(year, month = null) {
         let month2 = getJalaliMonthName(year, month, 28)
         if (month1 == month2) {
             // same month
-            return yearStr1 + " " + month1
+            return month1 + " " + yearStr1
         } else {
             // different month
             // check for different year
             if (yearStr1 == yearStr2) {
-                return `${yearStr1} ${month1}-${month2}`
+                return `${month1}-${month2} ${yearStr1}`
             } else {
-                return `${yearStr1} ${month1} - ${yearStr2} ${month2}`
+                return `${month1} ${yearStr1} - ${month2} ${yearStr2}`
             }
         }
     }

--- a/convert.js
+++ b/convert.js
@@ -1,0 +1,59 @@
+
+function getJalaliMonthName(year, month, day) {
+    const gregorianDate = new Date(year, month, day)
+    const onlyMonthDateFormatter = new Intl.DateTimeFormat("fa-IR", { month: 'long' })
+    return onlyMonthDateFormatter.format(gregorianDate);
+}
+
+function getEstimatedJalaliString(year, month = null) {
+    // process for year and month
+    if (month !== null) {
+        // get year in jalali time
+        // TODO: check for different years in start and end of the month
+        const dateObj = new Date(year, month, 1)
+        const onlyYearDateFormatter = new Intl.DateTimeFormat("fa-IR", { year: 'numeric' })
+        const yearStr = onlyYearDateFormatter.format(dateObj);
+
+
+        // TODO: handle for 31-days months
+        let month1 = getJalaliMonthName(year, month, 1)
+        let month2 = getJalaliMonthName(year, month, 28)
+        if (month1 == month2) {
+            // same month
+            return yearStr + " " + month1
+        } else {
+            // different month
+            return yearStr + " " + month1 + "-" + month2
+        }
+    }
+
+    // process for only year
+    const date1 = new Date(year, 1, 1)
+    const date2 = new Date(year, 12, 31)
+    const onlyYearDateFormatter = new Intl.DateTimeFormat("fa-IR", { year: 'numeric' })
+    let yearStr1 = onlyYearDateFormatter.format(date1);
+    let yearStr2 = onlyYearDateFormatter.format(date2);
+    if (yearStr1 == yearStr2) {
+        return yearStr1;
+    }
+    return yearStr1 + "-" + yearStr2
+}
+
+// console.log(jalaali.toJalaali(1975, 1, 1).jy, jalaali.toJalaali(1975, 12, 31).jy)
+// jalaali.
+// console.log(getEstimatedJalaliString(2020, 9))
+// console.log(getEstimatedJalaliString(2022))
+// d = new Date(2020, 9, 1)
+// console.log(new Intl.DateTimeFormat('en-US-u-ca-persian', { dateStyle: 'full' }).format(d))
+// console.log(getJalaliMonthName(1975, 12))
+
+
+// const DATE_PATTERNS = {
+//     // YYYY : only a 4-digit year
+//     YEAR: /(\d{2,4})/,
+//     // M Y : year and month
+//     YEAR_MONTH: /^(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s*,?\s*(\d{2,4})$/i,
+// }
+
+// // console.log(DATE_PATTERNS.YEAR.exec("1977 oajodaw")[1])
+// console.log(DATE_PATTERNS.YEAR_MONTH.exec("jAN 1977")[2])

--- a/convert.js
+++ b/convert.js
@@ -9,10 +9,9 @@ function getEstimatedJalaliString(year, month = null) {
     // process for year and month
     if (month !== null) {
         // get year in jalali time
-        // TODO: check for different years in start and end of the month
-        const dateObj = new Date(year, month, 1)
         const onlyYearDateFormatter = new Intl.DateTimeFormat("fa-IR", { year: 'numeric' })
-        const yearStr = onlyYearDateFormatter.format(dateObj);
+        const yearStr1 = onlyYearDateFormatter.format(new Date(year, month, 1));
+        const yearStr2 = onlyYearDateFormatter.format(new Date(year, month, 28));
 
 
         // TODO: handle for 31-days months
@@ -20,10 +19,15 @@ function getEstimatedJalaliString(year, month = null) {
         let month2 = getJalaliMonthName(year, month, 28)
         if (month1 == month2) {
             // same month
-            return yearStr + " " + month1
+            return yearStr1 + " " + month1
         } else {
             // different month
-            return yearStr + " " + month1 + "-" + month2
+            // check for different year
+            if (yearStr1 == yearStr2) {
+                return `${yearStr1} ${month1}-${month2}`
+            } else {
+                return `${yearStr1} ${month1} - ${yearStr2} ${month2}`
+            }
         }
     }
 

--- a/convert.js
+++ b/convert.js
@@ -1,68 +1,48 @@
-
 function getJalaliMonthName(year, month, day) {
-    const gregorianDate = new Date(year, month, day)
-    const onlyMonthDateFormatter = new Intl.DateTimeFormat("fa-IR", { month: 'long' })
-    return onlyMonthDateFormatter.format(gregorianDate);
+  const gregorianDate = new Date(year, month, day);
+  const onlyMonthDateFormatter = new Intl.DateTimeFormat('fa-IR', { month: 'long' });
+  return onlyMonthDateFormatter.format(gregorianDate);
 }
 
+// (will use in other file)
+// eslint-disable-next-line no-unused-vars
 function getEstimatedJalaliString(year, month = null) {
-    // process for year and month
-    if (month !== null) {
-        // get year in jalali time
-        const onlyYearDateFormatter = new Intl.DateTimeFormat("fa-IR", { year: 'numeric' })
-        const yearStr1 = onlyYearDateFormatter.format(new Date(year, month, 1));
-        const yearStr2 = onlyYearDateFormatter.format(new Date(year, month, 28));
+  // process for year and month
+  if (month !== null) {
+    // get year in jalali time
+    const onlyYearDateFormatter = new Intl.DateTimeFormat('fa-IR', { year: 'numeric' });
+    const yearStr1 = onlyYearDateFormatter.format(new Date(year, month, 1));
+    const yearStr2 = onlyYearDateFormatter.format(new Date(year, month, 28));
 
-        // check negative years
-        if (yearStr1.includes('−') || yearStr2.includes('−')) return null
-
-        // TODO: handle for 31-days months
-        let month1 = getJalaliMonthName(year, month, 1)
-        let month2 = getJalaliMonthName(year, month, 28)
-        if (month1 == month2) {
-            // same month
-            return month1 + " " + yearStr1
-        } else {
-            // different month
-            // check for different year
-            if (yearStr1 == yearStr2) {
-                return `${month1}-${month2} ${yearStr1}`
-            } else {
-                return `${month1} ${yearStr1} - ${month2} ${yearStr2}`
-            }
-        }
-    }
-
-    // process for only year
-    const date1 = new Date(year, 1, 1)
-    const date2 = new Date(year, 12, 31)
-    const onlyYearDateFormatter = new Intl.DateTimeFormat("fa-IR", { year: 'numeric' })
-    let yearStr1 = onlyYearDateFormatter.format(date1);
-    let yearStr2 = onlyYearDateFormatter.format(date2);
     // check negative years
-    if (yearStr1.includes('−') || yearStr2.includes('−')) return null
+    if (yearStr1.includes('−') || yearStr2.includes('−')) return null;
 
-    if (yearStr1 == yearStr2) {
-        return yearStr1;
+    // TODO: handle for 31-days months
+    const month1 = getJalaliMonthName(year, month, 1);
+    const month2 = getJalaliMonthName(year, month, 28);
+    if (month1 === month2) {
+      // same month
+      return `${month1} ${yearStr1}`;
     }
-    return yearStr1 + "-" + yearStr2
+    // different month
+    // check for different year
+    if (yearStr1 === yearStr2) {
+      return `${month1}-${month2} ${yearStr1}`;
+    }
+    return `${month1} ${yearStr1} - ${month2} ${yearStr2}`;
+  }
+
+  // process for only year
+  const date1 = new Date(year, 1, 1);
+  const date2 = new Date(year, 12, 31);
+  const onlyYearDateFormatter = new Intl.DateTimeFormat('fa-IR', { year: 'numeric' });
+  const yearStr1 = onlyYearDateFormatter.format(date1);
+  const yearStr2 = onlyYearDateFormatter.format(date2);
+  // check negative years
+  if (yearStr1.includes('−') || yearStr2.includes('−')) return null;
+
+  if (yearStr1 === yearStr2) {
+    return yearStr1;
+  }
+  return `${yearStr1}-${yearStr2}`;
 }
-
-// console.log(jalaali.toJalaali(1975, 1, 1).jy, jalaali.toJalaali(1975, 12, 31).jy)
-// jalaali.
-// console.log(getEstimatedJalaliString(2020, 9))
-// console.log(getEstimatedJalaliString(2022))
-// d = new Date(2020, 9, 1)
-// console.log(new Intl.DateTimeFormat('en-US-u-ca-persian', { dateStyle: 'full' }).format(d))
-// console.log(getJalaliMonthName(1975, 12))
-
-
-// const DATE_PATTERNS = {
-//     // YYYY : only a 4-digit year
-//     YEAR: /(\d{2,4})/,
-//     // M Y : year and month
-//     YEAR_MONTH: /^(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s*,?\s*(\d{2,4})$/i,
-// }
-
-// // console.log(DATE_PATTERNS.YEAR.exec("1977 oajodaw")[1])
-// console.log(DATE_PATTERNS.YEAR_MONTH.exec("jAN 1977")[2])

--- a/index.js
+++ b/index.js
@@ -1,20 +1,19 @@
-const TOOLTIP_ELEMENT_ID = "gtjwe-tooltip";
+const TOOLTIP_ELEMENT_ID = 'gtjwe-tooltip';
 
-const DATE_PATTERNS = {
+const DATE_LIKE_PATTERNS = {
   // YYYY : only a 4-digit year
   YEAR: /^(\d{3,4})$/i,
   // M Y : year and month
   YEAR_MONTH: /^(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s*,?\s*(\d{3,4})$/i,
-}
+};
 
 function createTooltipElement() {
-  const tooltipElement = document.createElement("div");
+  const tooltipElement = document.createElement('div');
   tooltipElement.id = TOOLTIP_ELEMENT_ID;
-  tooltipElement.style =
-    "position: absolute; background-color: black; color: white; padding: .1rem .5rem; border-radius: 3px; font-size: 1rem; line-height: 1rem z-index: 100; display: none; transform: translateX(-50%);";
-  tooltipElement.textContent = "";
-  tooltipElement.dir = "auto";
-  document.getElementsByTagName("body")[0].appendChild(tooltipElement);
+  tooltipElement.style = 'position: absolute; background-color: black; color: white; padding: .1rem .5rem; border-radius: 3px; font-size: 1rem; line-height: 1rem z-index: 100; display: none; transform: translateX(-50%);';
+  tooltipElement.textContent = '';
+  tooltipElement.dir = 'auto';
+  document.getElementsByTagName('body')[0].appendChild(tooltipElement);
 }
 
 function getTooltipCoordinate(selection) {
@@ -54,8 +53,9 @@ function processSelection(selection) {
   // trim, then remove st, nd, rd, th from day numbers if exist, then remove symbols from start/end
   const selectionContent = selection.toString().trim().replace(
     /\b(\d+)(st|nd|rd|th)\b/gi,
-    "$1",
-  ).replace(/(^[-_=\+\(\),\.]|[-_=\+\(\),\.]$)/, "").trim();
+    '$1',
+  ).replace(/(^[-_=+(),.]+|[-_=+(),.]+$)/gm, '') // eslint-disable-line no-useless-escape
+    .trim();
 
   if (canBeDate(selectionContent)) {
     const theTimestamp = Date.parse(selectionContent);
@@ -64,38 +64,39 @@ function processSelection(selection) {
     const gregorianDate = new Date(theTimestamp);
     if (gregorianDate.getFullYear() < 0) return null;
 
-    let dateStr = gregorianDate.toLocaleString("fa-IR", { dateStyle: "long" });
-    if (dateStr.includes('−') || dateStr.includes('−')) return null
+    const dateStr = gregorianDate.toLocaleString('fa-IR', { dateStyle: 'long' });
+    if (dateStr.includes('−') || dateStr.includes('−')) return null;
     return dateStr;
-
-  } else {
-    // process for an estimaed date (year, or year/month)
-    if (DATE_PATTERNS.YEAR_MONTH.test(selectionContent)) {
-      // year and month
-      const regexMatch = DATE_PATTERNS.YEAR_MONTH.exec(selectionContent)
-      const year = Number(regexMatch[2])
-      const monthName = regexMatch[1]
-
-      // Convert month name to index (0-based)
-      const monthIndex = new Date(`1 ${monthName} ${year}`).getMonth();
-
-      return getEstimatedJalaliString(year, monthIndex);
-
-    } else if (DATE_PATTERNS.YEAR.test(selectionContent)) {
-      // only year
-      const year = Number(DATE_PATTERNS.YEAR.exec(selectionContent)[1])
-      return getEstimatedJalaliString(year);
-    } else {
-      return null;
-    }
   }
+  // process for an estimaed date (year, or year/month)
+  if (DATE_LIKE_PATTERNS.YEAR_MONTH.test(selectionContent)) {
+    // year and month
+    const regexMatch = DATE_LIKE_PATTERNS.YEAR_MONTH.exec(selectionContent);
+    const year = Number(regexMatch[2]);
+    const monthName = regexMatch[1];
+
+    // Convert month name to index (0-based)
+    const monthIndex = new Date(`1 ${monthName} ${year}`).getMonth();
+
+    // defined in other file
+    // eslint-disable-next-line no-undef
+    return getEstimatedJalaliString(year, monthIndex);
+  } if (DATE_LIKE_PATTERNS.YEAR.test(selectionContent)) {
+    // only year
+    const year = Number(DATE_LIKE_PATTERNS.YEAR.exec(selectionContent)[1]);
+
+    // defined in other file
+    // eslint-disable-next-line no-undef
+    return getEstimatedJalaliString(year);
+  }
+  return null;
 }
 
 function removeTooltip(tooltip) {
   // eslint-disable-next-line no-param-reassign
-  tooltip.textContent = "";
+  tooltip.textContent = '';
   // eslint-disable-next-line no-param-reassign
-  tooltip.style.display = "none";
+  tooltip.style.display = 'none';
 }
 
 createTooltipElement();
@@ -114,7 +115,7 @@ document.onselectionchange = () => {
   const { x, y } = getTooltipCoordinate(selection);
 
   tooltipElement.textContent = tooltipContent;
-  tooltipElement.style.display = "block";
+  tooltipElement.style.display = 'block';
   tooltipElement.style.left = `${x}px`;
   tooltipElement.style.top = `${y}px`;
 };

--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@ const TOOLTIP_ELEMENT_ID = "gtjwe-tooltip";
 
 const DATE_PATTERNS = {
   // YYYY : only a 4-digit year
-  YEAR: /^(\d{2,4})$/i,
+  YEAR: /^(\d{3,4})$/i,
   // M Y : year and month
-  YEAR_MONTH: /^(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s*,?\s*(\d{2,4})$/i,
+  YEAR_MONTH: /^(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s*,?\s*(\d{3,4})$/i,
 }
 
 function createTooltipElement() {
@@ -64,7 +64,9 @@ function processSelection(selection) {
     const gregorianDate = new Date(theTimestamp);
     if (gregorianDate.getFullYear() < 0) return null;
 
-    return gregorianDate.toLocaleString("fa-IR", { dateStyle: "long" });
+    let dateStr = gregorianDate.toLocaleString("fa-IR", { dateStyle: "long" });
+    if (dateStr.includes('−') || dateStr.includes('−')) return null
+    return dateStr;
 
   } else {
     // process for an estimaed date (year, or year/month)

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,10 @@
       "matches": [
         "<all_urls>"
       ],
-      "js": ["./index.js"]
+      "js": [
+        "./convert.js",
+        "./index.js"
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Changes
Now the extension support more date-like strings such as :
- Only year for example : `1992`, it will display year(s) in the jalali calendar that include this year.  → `۱۳۷۰-۱۳۷۱`
- Only year+month for example : `January 1992`, it will display year and months in the jalali calendar that include this year and month  → `۱۳۷۰ دی-بهمن`

i'm not sure is it a good idea to show two months (or year) to include both start and end of a year (or month), or just show based on the start or its end, now is more clear, but I want to know your opinion about this.

- also, now the jalali dates with negative year will be ignored.


# Screenshots
<img src="https://github.com/user-attachments/assets/f53d2567-6838-41e5-b411-0d90d5fadd2c" width="500px">
<img src="https://github.com/user-attachments/assets/d5bcb5ef-e483-4ee0-b044-f34a8fa8e83a" width="500px">

